### PR TITLE
When running in Deno, `Buffer.prototype.latin1Slice` will not be used.

### DIFF
--- a/main.js
+++ b/main.js
@@ -8,6 +8,7 @@ let _bytesToStr = (
     )
         ? (bytes) => Buffer.prototype.latin1Slice.call(bytes)
         : (bytes) => {
+            // TextDecoder keeps the default UTF-8, which is already the fastest.
             const td = new TextDecoder
             return (_bytesToStr = (bytes) => td.decode(bytes))(bytes)
         }

--- a/main.js
+++ b/main.js
@@ -1,9 +1,23 @@
+let _bytesToStr = (bytes) => {
+    if (
+        typeof Buffer == 'function' &&
+        Buffer.prototype &&
+        typeof Buffer.prototype.latin1Slice == 'function' &&
+        typeof Deno == 'undefined'
+    ) return (_bytesToStr = (bytes) => Buffer.prototype.latin1Slice.call(bytes))(bytes)
+    const td = new TextDecoder
+    return (_bytesToStr = (bytes) => td.decode(bytes))(bytes)
+}
+
 export class EncodeResult {
     /**
      * @param {Uint8Array<ArrayBuffer>} bytes 
      */
     constructor(bytes) {
         this.bytes = bytes
+    }
+    toString() {
+        return _bytesToStr(this.bytes)
     }
     toJSTemplateLiterals() {
         return `\`${this.toString().replace(
@@ -16,21 +30,6 @@ export class EncodeResult {
                         : '\\' + match
             )
         )}\``
-    }
-}
-
-if (
-    typeof Buffer == 'function' &&
-    Buffer.prototype &&
-    typeof Buffer.prototype.latin1Slice == 'function'
-) {
-    EncodeResult.prototype.toString = function () {
-        return Buffer.prototype.latin1Slice.call(this.bytes)
-    }
-} else {
-    let _textDecoder
-    EncodeResult.prototype.toString = function () {
-        return (_textDecoder || (_textDecoder = new TextDecoder)).decode(this.bytes)
     }
 }
 

--- a/main.js
+++ b/main.js
@@ -3,6 +3,7 @@ let _bytesToStr = (bytes) => {
         typeof Buffer == 'function' &&
         Buffer.prototype &&
         typeof Buffer.prototype.latin1Slice == 'function' &&
+        // Exclude Deno. See https://github.com/bddjr/base128/pull/4
         typeof Deno == 'undefined'
     ) return (_bytesToStr = (bytes) => Buffer.prototype.latin1Slice.call(bytes))(bytes)
     const td = new TextDecoder

--- a/main.js
+++ b/main.js
@@ -1,14 +1,17 @@
-let _bytesToStr = (bytes) => {
-    if (
+let _bytesToStr = (
+    (
         typeof Buffer == 'function' &&
         Buffer.prototype &&
         typeof Buffer.prototype.latin1Slice == 'function' &&
         // Exclude Deno. See https://github.com/bddjr/base128/pull/4
         typeof Deno == 'undefined'
-    ) return (_bytesToStr = (bytes) => Buffer.prototype.latin1Slice.call(bytes))(bytes)
-    const td = new TextDecoder
-    return (_bytesToStr = (bytes) => td.decode(bytes))(bytes)
-}
+    )
+        ? (bytes) => Buffer.prototype.latin1Slice.call(bytes)
+        : (bytes) => {
+            const td = new TextDecoder
+            return (_bytesToStr = (bytes) => td.decode(bytes))(bytes)
+        }
+)
 
 export class EncodeResult {
     /**

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
   ],
   "scripts": {
     "test": "es-check es6 --checkFeatures --module main.js && tsc && node scripts/test.mjs",
-    "test-deno": "deno run --allow-read=. --allow-write=. scripts/test.mjs",
-    "test-bun": "bun scripts/test.mjs",
+    "test:deno": "deno run --allow-read=. --allow-write=. scripts/test.mjs",
+    "test:bun": "bun scripts/test.mjs",
     "prepublishOnly": "node --run test"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   ],
   "scripts": {
     "test": "es-check es6 --checkFeatures --module main.js && tsc && node scripts/test.mjs",
+    "test-deno": "deno run --allow-read=. --allow-write=. scripts/test.mjs",
+    "test-bun": "bun scripts/test.mjs",
     "prepublishOnly": "node --run test"
   },
   "repository": {

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -1,7 +1,7 @@
 //@ts-check
 
 import base128 from "../main.js";
-import fs from "fs"
+import fs from "node:fs"
 
 const enableOutput = false
 


### PR DESCRIPTION
When testing a 50MB file with Deno, calling `Buffer.prototype.latin1Slice` is very slow, taking about 4 seconds. However, using `TextDecoder` in Deno takes only around 10 milliseconds.

This PR adds a conditional check: when running in Deno, `Buffer.prototype.latin1Slice` will not be used.

Test Deno:

```
deno run test:deno
```

deno 2.8.0

Before: 4025ms

```
50MB
file length: 50000000

base128:
time encode: 57.9ms
time toString: 4025ms
time toJSTemplateLiterals: 336ms
toJSTemplateLiterals length: 58486143
time eval: 1013ms
time decode: 167ms
equal: true

base64:
encoded length: 66666668
```

Now: 10.9ms
```
50MB
file length: 50000000

base128:
time encode: 58.5ms
time toString: 10.9ms
time toJSTemplateLiterals: 169ms
toJSTemplateLiterals length: 58486143
time eval: 1058ms
time decode: 168ms
equal: true

base64:
encoded length: 66666668
```

---

References:

https://github.com/denoland/deno/blob/5bd5a3b9572c3b36c02068afc681f65a1895d384/ext/node/polyfills/internal/buffer.mjs#L1090-L1092

```js
Buffer.prototype.latin1Slice = function latin1Slice(offset, length) {
  return _latin1Slice(this, offset, length);
};
```

https://github.com/denoland/deno/blob/5bd5a3b9572c3b36c02068afc681f65a1895d384/ext/node/polyfills/internal/buffer.mjs#L1276-L1288

```js
function _latin1Slice(buf, start, end) {
  let ret = "";
  if (!start || start < 0) {
    start = 0;
  }
  if (end === undefined || end > buf.length) {
    end = buf.length;
  }
  for (let i = start; i < end; ++i) {
    ret += StringFromCharCode(buf[i]);
  }
  return ret;
}
```