### PR TITLE
5.0.5 optimize toJSTemplateLiterals

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,3 +1,4 @@
+/** @type {(bytes: Uint8Array) => string} */
 let _bytesToStr = (
     (
         typeof Buffer == 'function' &&
@@ -26,10 +27,17 @@ let _bytesToStr = (
         }
 )
 
+const _replacer = (match) => {
+    switch (match) {
+        case '\r': return '\\r';
+        case '\\': return '\\\\';
+        case '`': return '\\`';
+        case '${': return '\\${';
+        default: return '<\\/script';
+    }
+}
+
 export class EncodeResult {
-    /**
-     * @param {Uint8Array<ArrayBuffer>} bytes 
-     */
     constructor(bytes) {
         this.bytes = bytes
     }
@@ -39,13 +47,7 @@ export class EncodeResult {
     toJSTemplateLiterals() {
         return `\`${this.toString().replace(
             /[\r\\`]|\$\{|<\/script/g,
-            (match) => (
-                match === '\r'
-                    ? '\\r'
-                    : match === '</script'
-                        ? '<\\/script'
-                        : '\\' + match
-            )
+            _replacer
         )}\``
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "base128-ascii",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "author": "bddjr",
   "license": "Unlicense",
   "type": "module",


### PR DESCRIPTION
Before:

```
50MB
file length: 50000000

base128:
time encode: 67.846ms
time toString: 10.381ms
time toJSTemplateLiterals: 198.508ms
toJSTemplateLiterals length: 58486143
time eval: 1.072s
time decode: 186.201ms
equal: true

base64:
encoded length: 66666668
```

Now:

```
50MB
file length: 50000000

base128:
time encode: 68.032ms
time toString: 10.238ms
time toJSTemplateLiterals: 162.134ms
toJSTemplateLiterals length: 58486143
time eval: 1.044s
time decode: 183.296ms
equal: true

base64:
encoded length: 66666668
```

我还测试了Deno和Bun，现在的方案已经是最平衡的方案了，虽然不是在Node.js上最快的方案。

如果还想在所有环境里都更快，可能需要使用WebAssembly。